### PR TITLE
Support multiple device IDs per topic from CSV

### DIFF
--- a/InstructionForm.cs
+++ b/InstructionForm.cs
@@ -26,7 +26,7 @@ namespace MQTTMessageSenderApp
                        "勾选后每次重新连接时，都会接收最后一条保留消息。\n\n" +
                        "用户名和密码是非必填项。\n\n" +
                        "多线程中对于csv的要求为：\n" +
-                       "A列为Topic，B列为用户名，C列为密码，逗号分隔。\n\n" +
+                       "A列为Topic，B列为用户名，C列为密码，D列为设备编号(device_id)，逗号分隔。\n\n" +
                        "今日推荐：Piano Concerto No. 1 in G Minor, Op. 25, MWV O7 - I. Molto allegro con fuoco\n\n" +
                        "Version: 0.5.0.0-rc\n\n" +
                        "Welcome Aboard!  -- ANA3401",

--- a/MultiThreadPanelBuilder.cs
+++ b/MultiThreadPanelBuilder.cs
@@ -93,8 +93,13 @@ namespace MQTTMessageSenderApp
                     var topics = new List<string>();
                     var usernames = new List<string>();
                     var passwords = new List<string>();
+                    var deviceIdList = new List<List<string>>();
 
                     statusPanel.Controls.Clear();
+
+                    var topicUserMap = new Dictionary<string, string>();
+                    var topicPassMap = new Dictionary<string, string>();
+                    var topicDeviceMap = new Dictionary<string, List<string>>();
 
                     for (int i = 0; i < lines.Count; i++)
                     {
@@ -104,19 +109,34 @@ namespace MQTTMessageSenderApp
                         var topic = cols[0].Trim();
                         var user = cols.Length > 1 ? cols[1].Trim() : "";
                         var pass = cols.Length > 2 ? cols[2].Trim() : "";
+                        var device = cols.Length > 3 ? cols[3].Trim() : "";
 
-                        topics.Add(topic);
-                        usernames.Add(user);
-                        passwords.Add(pass);
+                        if (!topicDeviceMap.ContainsKey(topic))
+                        {
+                            topicDeviceMap[topic] = new List<string>();
+                            topicUserMap[topic] = user;
+                            topicPassMap[topic] = pass;
+                        }
+
+                        if (!string.IsNullOrWhiteSpace(device))
+                            topicDeviceMap[topic].Add(device);
+                    }
+
+                    foreach (var kvp in topicDeviceMap)
+                    {
+                        topics.Add(kvp.Key);
+                        usernames.Add(topicUserMap[kvp.Key]);
+                        passwords.Add(topicPassMap[kvp.Key]);
+                        deviceIdList.Add(kvp.Value);
 
                         var lbl = new Label
                         {
-                            Text = $"[{topic}] 状态：等待启动...",
+                            Text = $"[{kvp.Key}] 状态：等待启动...",
                             AutoSize = true,
                             Width = 700,
                             Font = font
                         };
-                        MultiThreadTaskManager.RegisterThreadStatus(topic, lbl);
+                        MultiThreadTaskManager.RegisterThreadStatus(kvp.Key, lbl);
                         statusPanel.Controls.Add(lbl);
                     }
 
@@ -134,7 +154,8 @@ namespace MQTTMessageSenderApp
                         chkRetain.Checked,
                         topics,
                         usernames,
-                        passwords
+                        passwords,
+                        deviceIdList
                     );
                 }
                 catch (Exception ex)

--- a/MultiThreadTaskManager.cs
+++ b/MultiThreadTaskManager.cs
@@ -102,7 +102,7 @@ namespace MQTTMessageSenderApp
         }
 
         public static void StartAll(string broker, int port, int keepalive, int interval, bool retain,
-                                     List<string> topics, List<string> usernames, List<string> passwords)
+                                     List<string> topics, List<string> usernames, List<string> passwords, List<List<string>> deviceIdsList)
         {
             StopAll();
 
@@ -114,6 +114,7 @@ namespace MQTTMessageSenderApp
                 string topic = topics[i].Trim();
                 string username = usernames[i].Trim();
                 string password = passwords[i].Trim();
+                var deviceIds = deviceIdsList[i];
 
                 messageCountMap[topic] = 0;
 
@@ -143,7 +144,7 @@ namespace MQTTMessageSenderApp
 
                             while (!token.IsCancellationRequested && mqttClient.IsConnected)
                             {
-                                string message = await MessageFileHandler.ReadMessageAsync();
+                                string message = await MessageFileHandler.ReadMessageAsync(deviceIds);
 
                                 var mqttMessage = new MqttApplicationMessageBuilder()
                                     .WithTopic(topic)


### PR DESCRIPTION
## Summary
- parse device_id column from CSV and group IDs per topic
- pass device lists to multi-thread task manager and message builder
- update instructions to include device_id column

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a68ffa5510832cabeda7adf7b2f0c1