### PR TITLE
feat: support device point mapping for multi-threaded MQTT

### DIFF
--- a/MultiThreadPanelBuilder.cs
+++ b/MultiThreadPanelBuilder.cs
@@ -93,13 +93,13 @@ namespace MQTTMessageSenderApp
                     var topics = new List<string>();
                     var usernames = new List<string>();
                     var passwords = new List<string>();
-                    var deviceIdList = new List<List<string>>();
+                    var devicePointMapList = new List<Dictionary<string, List<string>>>();
 
                     statusPanel.Controls.Clear();
 
                     var topicUserMap = new Dictionary<string, string>();
                     var topicPassMap = new Dictionary<string, string>();
-                    var topicDeviceMap = new Dictionary<string, List<string>>();
+                    var topicDevicePointMap = new Dictionary<string, Dictionary<string, List<string>>>();
 
                     for (int i = 0; i < lines.Count; i++)
                     {
@@ -110,24 +110,33 @@ namespace MQTTMessageSenderApp
                         var user = cols.Length > 1 ? cols[1].Trim() : "";
                         var pass = cols.Length > 2 ? cols[2].Trim() : "";
                         var device = cols.Length > 3 ? cols[3].Trim() : "";
+                        var points = cols.Length > 4 ? cols[4].Trim() : "";
 
-                        if (!topicDeviceMap.ContainsKey(topic))
+                        if (!topicDevicePointMap.ContainsKey(topic))
                         {
-                            topicDeviceMap[topic] = new List<string>();
+                            topicDevicePointMap[topic] = new Dictionary<string, List<string>>();
                             topicUserMap[topic] = user;
                             topicPassMap[topic] = pass;
                         }
 
                         if (!string.IsNullOrWhiteSpace(device))
-                            topicDeviceMap[topic].Add(device);
+                        {
+                            var pointList = new List<string>();
+                            if (!string.IsNullOrWhiteSpace(points))
+                            {
+                                pointList = points.Split(new[] { '|', ';' }, StringSplitOptions.RemoveEmptyEntries)
+                                                   .Select(p => p.Trim()).ToList();
+                            }
+                            topicDevicePointMap[topic][device] = pointList;
+                        }
                     }
 
-                    foreach (var kvp in topicDeviceMap)
+                    foreach (var kvp in topicDevicePointMap)
                     {
                         topics.Add(kvp.Key);
                         usernames.Add(topicUserMap[kvp.Key]);
                         passwords.Add(topicPassMap[kvp.Key]);
-                        deviceIdList.Add(kvp.Value);
+                        devicePointMapList.Add(kvp.Value);
 
                         var lbl = new Label
                         {
@@ -155,7 +164,7 @@ namespace MQTTMessageSenderApp
                         topics,
                         usernames,
                         passwords,
-                        deviceIdList
+                        devicePointMapList
                     );
                 }
                 catch (Exception ex)

--- a/MultiThreadTaskManager.cs
+++ b/MultiThreadTaskManager.cs
@@ -102,7 +102,7 @@ namespace MQTTMessageSenderApp
         }
 
         public static void StartAll(string broker, int port, int keepalive, int interval, bool retain,
-                                     List<string> topics, List<string> usernames, List<string> passwords, List<List<string>> deviceIdsList)
+                                     List<string> topics, List<string> usernames, List<string> passwords, List<Dictionary<string, List<string>>> devicePointMap)
         {
             StopAll();
 
@@ -114,7 +114,7 @@ namespace MQTTMessageSenderApp
                 string topic = topics[i].Trim();
                 string username = usernames[i].Trim();
                 string password = passwords[i].Trim();
-                var deviceIds = deviceIdsList[i];
+                var devicePoints = devicePointMap[i];
 
                 messageCountMap[topic] = 0;
 
@@ -144,7 +144,7 @@ namespace MQTTMessageSenderApp
 
                             while (!token.IsCancellationRequested && mqttClient.IsConnected)
                             {
-                                string message = await MessageFileHandler.ReadMessageAsync(deviceIds);
+                                string message = await MessageFileHandler.ReadMessageAsync(devicePoints);
 
                                 var mqttMessage = new MqttApplicationMessageBuilder()
                                     .WithTopic(topic)


### PR DESCRIPTION
## Summary
- allow StartAll to accept device point mappings and pass them to message generator
- parse device-point lists from CSV and supply to StartAll
- generate MQTT messages based on device-point map and filter points accordingly

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6bedf42cc832cb09ab9b7e4373f3a