### PR TITLE
Add concurrency controls, MQTT client pooling and queued logging

### DIFF
--- a/MqttClientPool.cs
+++ b/MqttClientPool.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MQTTnet;
+using MQTTnet.Client;
+
+namespace MQTTMessageSenderApp
+{
+    public class MqttClientPool
+    {
+        private readonly string broker;
+        private readonly int port;
+        private readonly int keepalive;
+        private readonly string username;
+        private readonly string password;
+        private readonly SemaphoreSlim semaphore;
+        private readonly ConcurrentBag<IMqttClient> clients = new();
+        private readonly MqttClientFactory factory = new();
+
+        public MqttClientPool(string broker, int port, int keepalive, string username, string password, int maxConnections)
+        {
+            this.broker = broker;
+            this.port = port;
+            this.keepalive = keepalive;
+            this.username = username;
+            this.password = password;
+            semaphore = new SemaphoreSlim(maxConnections);
+        }
+
+        public async Task<IMqttClient> GetClientAsync(CancellationToken token)
+        {
+            await semaphore.WaitAsync(token);
+
+            if (clients.TryTake(out var client) && client.IsConnected)
+            {
+                return client;
+            }
+
+            var mqttClient = factory.CreateMqttClient();
+            var builder = new MqttClientOptionsBuilder()
+                .WithTcpServer(broker, port)
+                .WithKeepAlivePeriod(TimeSpan.FromSeconds(keepalive));
+            if (!string.IsNullOrWhiteSpace(username))
+                builder = builder.WithCredentials(username, password);
+            var options = builder.Build();
+            await mqttClient.ConnectAsync(options, token);
+            return mqttClient;
+        }
+
+        public void ReturnClient(IMqttClient client)
+        {
+            if (client != null && client.IsConnected)
+            {
+                clients.Add(client);
+            }
+            else
+            {
+                client?.Dispose();
+            }
+            semaphore.Release();
+        }
+
+        public async Task DisposeAsync()
+        {
+            while (clients.TryTake(out var client))
+            {
+                try
+                {
+                    if (client.IsConnected)
+                        await client.DisconnectAsync();
+                }
+                catch { }
+                client.Dispose();
+            }
+        }
+    }
+
+    public static class MqttClientPoolManager
+    {
+        private static readonly ConcurrentDictionary<string, MqttClientPool> pools = new();
+
+        public static MqttClientPool GetPool(string broker, int port, int keepalive, string username, string password, int maxConnections)
+        {
+            string key = $"{broker}:{port}:{username}:{password}";
+            return pools.GetOrAdd(key, _ => new MqttClientPool(broker, port, keepalive, username, password, maxConnections));
+        }
+
+        public static async Task DisposeAllAsync()
+        {
+            foreach (var pool in pools.Values)
+            {
+                await pool.DisposeAsync();
+            }
+            pools.Clear();
+        }
+    }
+}

--- a/MultiThreadPanelBuilder.cs
+++ b/MultiThreadPanelBuilder.cs
@@ -27,6 +27,8 @@ namespace MQTTMessageSenderApp
             var txtKeepAlive = new TextBox { Width = 360, Font = font, Text = "60" };
             var txtInterval = new TextBox { Width = 360, Font = font, Text = "10000" };
             var chkRetain = new CheckBox { Text = "Retain Message", Font = font, AutoSize = true };
+            var txtMaxConcurrency = new TextBox { Width = 360, Font = font, Text = "500" };
+            var txtLogFlush = new TextBox { Width = 360, Font = font, Text = "500" };
 
             var txtCsvFile = new TextBox { Width = 360, Font = font, ReadOnly = true };
             var btnCsvFile = new Button { Text = "选择 CSV 文件", Width = 160, Height = 36, Font = font };
@@ -73,6 +75,8 @@ namespace MQTTMessageSenderApp
                 if (!int.TryParse(txtPort.Text, out int port) ||
                     !int.TryParse(txtKeepAlive.Text, out int keepalive) ||
                     !int.TryParse(txtInterval.Text, out int interval) ||
+                    !int.TryParse(txtMaxConcurrency.Text, out int maxConc) ||
+                    !int.TryParse(txtLogFlush.Text, out int logFlush) ||
                     string.IsNullOrWhiteSpace(txtBroker.Text) ||
                     string.IsNullOrWhiteSpace(txtCsvFile.Text) ||
                     !File.Exists(txtCsvFile.Text))
@@ -155,7 +159,9 @@ namespace MQTTMessageSenderApp
                         topics,
                         usernames,
                         passwords,
-                        deviceIdList
+                        deviceIdList,
+                        maxConc,
+                        logFlush
                     );
                 }
                 catch (Exception ex)
@@ -180,6 +186,8 @@ namespace MQTTMessageSenderApp
             AddRow("KeepAlive:", txtKeepAlive);
             AddRow("Interval(ms):", txtInterval);
             AddRow("Retain:", chkRetain);
+            AddRow("Max Concurrency:", txtMaxConcurrency);
+            AddRow("Log Flush(ms):", txtLogFlush);
             AddRow("CSV 文件:", txtCsvFile, btnCsvFile);
 
             var actionRow = new FlowLayoutPanel { AutoSize = true, FlowDirection = FlowDirection.LeftToRight };

--- a/MultiThreadTaskManager.cs
+++ b/MultiThreadTaskManager.cs
@@ -1,10 +1,13 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using MQTTnet;
+using MQTTnet.Client;
 
 namespace MQTTMessageSenderApp
 {
@@ -15,11 +18,20 @@ namespace MQTTMessageSenderApp
         private static TextBox logBox;
         private static Dictionary<string, int> messageCountMap = new();
         private static Dictionary<string, Label> threadStatusMap = new();
+        private static readonly ConcurrentQueue<string> logQueue = new();
+        private static Timer logTimer;
+        private static SemaphoreSlim semaphore;
+
+        public static int MaxConcurrency { get; set; } = 500;
+        public static int LogFlushInterval { get; set; } = 500;
+
         private const int MaxLogLines = 500;
+        private const int MaxQueueLength = 10000;
 
         public static void BindLogBox(TextBox outputBox)
         {
             logBox = outputBox;
+            StartLogTimer();
         }
 
         public static void RegisterThreadStatus(string topic, Label statusLabel)
@@ -45,21 +57,41 @@ namespace MQTTMessageSenderApp
 
         private static void Log(string message)
         {
-            if (logBox?.InvokeRequired == true)
+            if (logQueue.Count < MaxQueueLength)
             {
-                logBox.Invoke((MethodInvoker)(() => AppendLog(message)));
-            }
-            else
-            {
-                AppendLog(message);
+                logQueue.Enqueue($"[{DateTime.Now:HH:mm:ss}] {message}");
             }
         }
 
-        private static void AppendLog(string message)
+        private static void FlushLogQueue(object state)
         {
             if (logBox == null) return;
 
-            logBox.AppendText($"[{DateTime.Now:HH:mm:ss}] {message}\r\n");
+            List<string> logs = new List<string>();
+            while (logQueue.TryDequeue(out var item))
+            {
+                logs.Add(item);
+            }
+
+            if (logs.Count == 0) return;
+
+            string text = string.Join(Environment.NewLine, logs) + Environment.NewLine;
+
+            if (logBox.InvokeRequired)
+            {
+                logBox.Invoke((MethodInvoker)(() => AppendLog(text)));
+            }
+            else
+            {
+                AppendLog(text);
+            }
+        }
+
+        private static void AppendLog(string text)
+        {
+            if (logBox == null) return;
+
+            logBox.AppendText(text);
 
             logBox.SelectionStart = logBox.Text.Length;
             logBox.ScrollToCaret();
@@ -72,6 +104,18 @@ namespace MQTTMessageSenderApp
                 Array.Copy(lines, removeCount, trimmed, 0, MaxLogLines);
                 logBox.Lines = trimmed;
             }
+        }
+
+        private static void StartLogTimer()
+        {
+            logTimer?.Dispose();
+            logTimer = new Timer(FlushLogQueue, null, 0, LogFlushInterval);
+        }
+
+        public static void SetLogFlushInterval(int interval)
+        {
+            LogFlushInterval = interval;
+            logTimer?.Change(0, LogFlushInterval);
         }
 
         public static void ExportLogToFile(string filePath)
@@ -102,12 +146,17 @@ namespace MQTTMessageSenderApp
         }
 
         public static void StartAll(string broker, int port, int keepalive, int interval, bool retain,
-                                     List<string> topics, List<string> usernames, List<string> passwords, List<List<string>> deviceIdsList)
+                                     List<string> topics, List<string> usernames, List<string> passwords, List<List<string>> deviceIdsList,
+                                     int? maxConcurrency = null, int? logFlushInterval = null)
         {
             StopAll();
 
+            if (maxConcurrency.HasValue) MaxConcurrency = maxConcurrency.Value;
+            if (logFlushInterval.HasValue) SetLogFlushInterval(logFlushInterval.Value);
+
             cts = new CancellationTokenSource();
             var token = cts.Token;
+            semaphore = new SemaphoreSlim(MaxConcurrency);
 
             for (int i = 0; i < topics.Count; i++)
             {
@@ -120,56 +169,61 @@ namespace MQTTMessageSenderApp
 
                 Task t = Task.Run(async () =>
                 {
-                    int retryCount = 0;
-                    while (!token.IsCancellationRequested)
+                    await semaphore.WaitAsync(token);
+                    var pool = MqttClientPoolManager.GetPool(broker, port, keepalive, username, password, MaxConcurrency);
+                    IMqttClient mqttClient = null;
+                    try
                     {
-                        try
+                        int retryCount = 0;
+                        mqttClient = await pool.GetClientAsync(token);
+                        while (!token.IsCancellationRequested)
                         {
-                            var factory = new MqttClientFactory();
-                            using var mqttClient = factory.CreateMqttClient();
-
-                            var builder = new MqttClientOptionsBuilder()
-                                .WithTcpServer(broker, port)
-                                .WithKeepAlivePeriod(TimeSpan.FromSeconds(keepalive));
-
-                            if (!string.IsNullOrWhiteSpace(username))
-                                builder = builder.WithCredentials(username, password);
-
-                            var options = builder.Build();
-                            await mqttClient.ConnectAsync(options, token);
-
-                            Log($"[{topic}] 已连接");
-                            UpdateThreadStatus(topic, "已连接");
-                            retryCount = 0;
-
-                            while (!token.IsCancellationRequested && mqttClient.IsConnected)
+                            try
                             {
-                                string message = await MessageFileHandler.ReadMessageAsync(deviceIds);
+                                if (!mqttClient.IsConnected)
+                                {
+                                    await Task.Delay(1000, token);
+                                    continue;
+                                }
 
-                                var mqttMessage = new MqttApplicationMessageBuilder()
-                                    .WithTopic(topic)
-                                    .WithPayload(message)
-                                    .WithRetainFlag(retain)
-                                    .Build();
+                                Log($"[{topic}] 已连接");
+                                UpdateThreadStatus(topic, "已连接");
+                                retryCount = 0;
 
-                                await mqttClient.PublishAsync(mqttMessage, token);
+                                while (!token.IsCancellationRequested && mqttClient.IsConnected)
+                                {
+                                    string message = await MessageFileHandler.ReadMessageAsync(deviceIds);
 
-                                messageCountMap[topic]++;
-                                Log($"[{topic}] 已发送消息，总计: {messageCountMap[topic]}");
-                                await Task.Delay(interval, token);
+                                    var mqttMessage = new MqttApplicationMessageBuilder()
+                                        .WithTopic(topic)
+                                        .WithPayload(message)
+                                        .WithRetainFlag(retain)
+                                        .Build();
+
+                                    await mqttClient.PublishAsync(mqttMessage, token);
+
+                                    messageCountMap[topic]++;
+                                    Log($"[{topic}] 已发送消息，总计: {messageCountMap[topic]}");
+                                    await Task.Delay(interval, token);
+                                }
+
+                                UpdateThreadStatus(topic, "已断开");
+                                Log($"[{topic}] 已断开连接");
                             }
-
-                            await mqttClient.DisconnectAsync();
-                            UpdateThreadStatus(topic, "已断开");
-                            Log($"[{topic}] 已断开连接");
+                            catch (Exception ex)
+                            {
+                                retryCount++;
+                                Log($"[{topic}] 异常({retryCount}): {ex.Message}");
+                                UpdateThreadStatus(topic, $"重试中({retryCount})");
+                                await Task.Delay(3000, token);
+                            }
                         }
-                        catch (Exception ex)
-                        {
-                            retryCount++;
-                            Log($"[{topic}] 异常({retryCount}): {ex.Message}");
-                            UpdateThreadStatus(topic, $"重试中({retryCount})");
-                            await Task.Delay(3000, token);
-                        }
+                    }
+                    finally
+                    {
+                        if (mqttClient != null)
+                            pool.ReturnClient(mqttClient);
+                        semaphore.Release();
                     }
                 }, token);
 
@@ -189,6 +243,10 @@ namespace MQTTMessageSenderApp
             tasks.Clear();
             messageCountMap.Clear();
             threadStatusMap.Clear();
+
+            semaphore?.Dispose();
+            logTimer?.Dispose();
+            MqttClientPoolManager.DisposeAllAsync().GetAwaiter().GetResult();
         }
     }
 }


### PR DESCRIPTION
## Summary
- limit multi-thread sender concurrency with configurable SemaphoreSlim
- reuse MQTT connections via pool to avoid per-topic clients
- queue logs and flush on timer with adjustable interval

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7dd94d974832c97157d6c6b2dd336